### PR TITLE
build(misc): fix no permission to trigger gh commenct

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
 
           gh pr comment $PR_NUMBER -F table.txt
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   java-unit-test:
     name: java-unit-test
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

In the PR https://github.com/mycloudnexus/vortex/pull/7, there is a error when running `gh comment`

```
GraphQL: Resource not accessible by integration (addComment)
```

looks like the above error only happen for the PR cross different organizations.
if the PR is within same organization , everything is good