### PR TITLE
feat(sdk): add organization member and invitation mgmt

### DIFF
--- a/vortex-app/vortex-app-api/src/main/resources/application.yaml
+++ b/vortex-app/vortex-app-api/src/main/resources/application.yaml
@@ -71,7 +71,7 @@ springdoc:
   swagger-ui:
     enabled: true
     path: /swagger-ui.html
-    supported-submit-methods: ["get", "post", "patch", "delete"]
+    supported-submit-methods: [ "get", "post", "patch", "delete" ]
     config-url: /v3/api-docs/swagger-config
     urls:
       - url: /v3/api-docs
@@ -86,7 +86,16 @@ logging:
 
 app:
   auth0:
-    domain: ${AUTH0_DOMAIN:consoleconnect.auth0.com}
-    audience: ${AUTH0_AUDIENCE:https://partner.consoleconnect.com/api}
-    client-id: ${AUTH0_CLIENT_ID:client-id}
-    client-secret: ${AUTH0_CLIENT_SECRET:client-secret}
+    mgmt-api:
+      domain: ${AUTH0_MGMT_API_DOMAIN:consoleconnect.auth0.com}
+      client-id: ${AUTH0_MGMT_API_CLIENT_ID:mgmt-api-client-id}
+      client-secret: ${AUTH0_MGMT_API_CLIENT_SECRET:mgmt-api-client-secret}
+      audience: ${AUTH0_MGMT_API_AUDIENCE:https://partner.consoleconnect.com/api}
+    app:
+      client-id: ${AUTH0_APP_CLIENT_ID:app-client-id}
+
+    mgmt-org-id: ${AUTH0_MGMT_ORG_ID:mgmt-org-id}
+    roles:
+      mgmt-role-id: ${AUTH0_MGMT_ROLE_ID:mgmt-role-id}
+      admin-role-id: ${AUTH0_ADMIN_ROLE_ID:admin-role-id}
+      user-role-id: ${AUTH0_USER_ROLE_ID:user-role-id}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/auth0/Auth0Client.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/auth0/Auth0Client.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 public class Auth0Client {
-  private final Auth0Property auth0Property;
+  @Getter private final Auth0Property auth0Property;
   private final AuthAPI auth0AuthAPI;
   private final Auth0HttpClient auth0HttpClient;
   private TokenHolder tokenHolder;
@@ -25,15 +25,15 @@ public class Auth0Client {
     this.auth0HttpClient = DefaultHttpClient.newBuilder().build();
     this.auth0AuthAPI =
         AuthAPI.newBuilder(
-                this.auth0Property.getDomain(),
-                this.auth0Property.getClientId(),
-                this.auth0Property.getClientSecret())
+                this.auth0Property.getMgmtApi().getDomain(),
+                this.auth0Property.getMgmtApi().getClientId(),
+                this.auth0Property.getMgmtApi().getClientSecret())
             .withHttpClient(auth0HttpClient)
             .build();
   }
 
   public ManagementAPI getMgmtClient() {
-    return ManagementAPI.newBuilder(auth0Property.getDomain(), getAccessToken())
+    return ManagementAPI.newBuilder(auth0Property.getMgmtApi().getDomain(), getAccessToken())
         .withHttpClient(auth0HttpClient)
         .build();
   }
@@ -42,7 +42,8 @@ public class Auth0Client {
     // Check if token is null or expired
     if (tokenHolder == null || new Date().after(tokenHolder.getExpiresAt())) {
       try {
-        TokenRequest tokenRequest = auth0AuthAPI.requestToken(auth0Property.getAudience());
+        TokenRequest tokenRequest =
+            auth0AuthAPI.requestToken(auth0Property.getMgmtApi().getAudience());
         tokenHolder = tokenRequest.execute().getBody();
       } catch (Exception e) {
         log.error("Error calling Auth0", e);

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/OrganizationInvitationController.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/OrganizationInvitationController.java
@@ -1,0 +1,65 @@
+package com.consoleconnect.vortex.iam.controller;
+
+import com.auth0.json.mgmt.organizations.Invitation;
+import com.consoleconnect.vortex.core.model.HttpResponse;
+import com.consoleconnect.vortex.core.toolkit.Paging;
+import com.consoleconnect.vortex.core.toolkit.PagingHelper;
+import com.consoleconnect.vortex.iam.dto.CreateInivitationDto;
+import com.consoleconnect.vortex.iam.service.OrganizationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.web.bind.annotation.*;
+
+@AllArgsConstructor
+@RestController()
+@RequestMapping(
+    value = "/organizations/{orgId}/invitations",
+    produces = MediaType.APPLICATION_JSON_VALUE)
+@Tag(name = "Organization", description = "Organization APIs")
+@Slf4j
+public class OrganizationInvitationController {
+
+  private final OrganizationService service;
+
+  @Operation(summary = "List all invitations")
+  @GetMapping("")
+  public HttpResponse<Paging<Invitation>> search(
+      @PathVariable String orgId,
+      @RequestParam(value = "page", required = false, defaultValue = PagingHelper.DEFAULT_PAGE_STR)
+          int page,
+      @RequestParam(value = "size", required = false, defaultValue = PagingHelper.DEFAULT_SIZE_STR)
+          int size) {
+    return HttpResponse.ok(service.listInvitations(orgId, page, size));
+  }
+
+  @Operation(summary = "Create a new invitation")
+  @PostMapping()
+  public HttpResponse<Invitation> create(
+      @PathVariable String orgId,
+      @RequestBody CreateInivitationDto request,
+      JwtAuthenticationToken jwtAuthenticationToken) {
+    return HttpResponse.ok(
+        service.createInvitation(orgId, request, jwtAuthenticationToken.getName()));
+  }
+
+  @Operation(summary = "Retrieve an invitation by id")
+  @GetMapping("/{invitationId}")
+  public HttpResponse<Invitation> findOne(
+      @PathVariable String orgId, @PathVariable String invitationId) {
+    return HttpResponse.ok(service.getInvitationById(orgId, invitationId));
+  }
+
+  @Operation(summary = "Delete an invitation by id")
+  @DeleteMapping("/{invitationId}")
+  public HttpResponse<Void> delete(
+      @PathVariable String orgId,
+      @PathVariable String invitationId,
+      JwtAuthenticationToken jwtAuthenticationToken) {
+    service.deleteInvitation(orgId, invitationId, jwtAuthenticationToken.getName());
+    return HttpResponse.ok(null);
+  }
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/OrganizationMemberController.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/OrganizationMemberController.java
@@ -1,0 +1,36 @@
+package com.consoleconnect.vortex.iam.controller;
+
+import com.auth0.json.mgmt.organizations.Member;
+import com.consoleconnect.vortex.core.model.HttpResponse;
+import com.consoleconnect.vortex.core.toolkit.Paging;
+import com.consoleconnect.vortex.core.toolkit.PagingHelper;
+import com.consoleconnect.vortex.iam.service.OrganizationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@AllArgsConstructor
+@RestController()
+@RequestMapping(
+    value = "/organizations/{orgId}/members",
+    produces = MediaType.APPLICATION_JSON_VALUE)
+@Tag(name = "Organization", description = "Organization APIs")
+@Slf4j
+public class OrganizationMemberController {
+
+  private final OrganizationService service;
+
+  @Operation(summary = "List all members")
+  @GetMapping("")
+  public HttpResponse<Paging<Member>> search(
+      @PathVariable String orgId,
+      @RequestParam(value = "page", required = false, defaultValue = PagingHelper.DEFAULT_PAGE_STR)
+          int page,
+      @RequestParam(value = "size", required = false, defaultValue = PagingHelper.DEFAULT_SIZE_STR)
+          int size) {
+    return HttpResponse.ok(service.listMembers(orgId, page, size));
+  }
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/OrganizationRoleController.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/OrganizationRoleController.java
@@ -1,0 +1,34 @@
+package com.consoleconnect.vortex.iam.controller;
+
+import com.auth0.json.mgmt.roles.Role;
+import com.consoleconnect.vortex.core.model.HttpResponse;
+import com.consoleconnect.vortex.core.toolkit.Paging;
+import com.consoleconnect.vortex.core.toolkit.PagingHelper;
+import com.consoleconnect.vortex.iam.service.OrganizationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+@AllArgsConstructor
+@RestController()
+@RequestMapping(value = "/organizations/{orgId}/roles", produces = MediaType.APPLICATION_JSON_VALUE)
+@Tag(name = "Organization", description = "Organization APIs")
+@Slf4j
+public class OrganizationRoleController {
+
+  private final OrganizationService service;
+
+  @Operation(summary = "List all roles")
+  @GetMapping("")
+  public HttpResponse<Paging<Role>> search(
+      @PathVariable String orgId,
+      @RequestParam(value = "page", required = false, defaultValue = PagingHelper.DEFAULT_PAGE_STR)
+          int page,
+      @RequestParam(value = "size", required = false, defaultValue = PagingHelper.DEFAULT_SIZE_STR)
+          int size) {
+    return HttpResponse.ok(service.listRoles(orgId, page, size));
+  }
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/dto/CreateInivitationDto.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/dto/CreateInivitationDto.java
@@ -1,0 +1,10 @@
+package com.consoleconnect.vortex.iam.dto;
+
+import com.consoleconnect.vortex.iam.enums.RoleEnum;
+import lombok.Data;
+
+@Data
+public class CreateInivitationDto {
+  private String email;
+  private RoleEnum role;
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/enums/RoleEnum.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/enums/RoleEnum.java
@@ -1,0 +1,6 @@
+package com.consoleconnect.vortex.iam.enums;
+
+public enum RoleEnum {
+  ADMIN,
+  USER
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/Auth0Property.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/Auth0Property.java
@@ -4,8 +4,25 @@ import lombok.Data;
 
 @Data
 public class Auth0Property {
-  private String domain;
-  private String clientId;
-  private String clientSecret;
-  private String audience;
+
+  private Config mgmtApi;
+  private Config app;
+
+  private String mgmtOrgId; // the organizationId for mgmt users
+  private Roles roles; // the role ids for mgmt, organization admin and organization user
+
+  @Data
+  public static class Config {
+    private String domain;
+    private String clientId;
+    private String clientSecret;
+    private String audience;
+  }
+
+  @Data
+  public static class Roles {
+    private String mgmtRoleId; // the role id for platform mgmt only
+    private String adminRoleId; // the role id for organization admin
+    private String userRoleId; // the role id for organization user
+  }
 }

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/OrganizationService.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/OrganizationService.java
@@ -1,17 +1,22 @@
 package com.consoleconnect.vortex.iam.service;
 
 import com.auth0.client.mgmt.OrganizationsEntity;
+import com.auth0.client.mgmt.RolesEntity;
 import com.auth0.client.mgmt.filter.PageFilter;
 import com.auth0.exception.Auth0Exception;
-import com.auth0.json.mgmt.organizations.EnabledConnectionsPage;
-import com.auth0.json.mgmt.organizations.Organization;
-import com.auth0.json.mgmt.organizations.OrganizationsPage;
+import com.auth0.json.mgmt.organizations.*;
+import com.auth0.json.mgmt.roles.Role;
+import com.auth0.json.mgmt.users.User;
 import com.auth0.net.Request;
 import com.consoleconnect.vortex.core.exception.VortexException;
 import com.consoleconnect.vortex.core.toolkit.Paging;
 import com.consoleconnect.vortex.core.toolkit.PagingHelper;
 import com.consoleconnect.vortex.iam.auth0.Auth0Client;
+import com.consoleconnect.vortex.iam.dto.CreateInivitationDto;
 import com.consoleconnect.vortex.iam.dto.CreateOrganizationDto;
+import com.consoleconnect.vortex.iam.enums.RoleEnum;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -61,6 +66,127 @@ public class OrganizationService {
       return organization;
     } catch (Auth0Exception e) {
       throw VortexException.internalError("Failed to get organization: " + orgId);
+    }
+  }
+
+  public Paging<Member> listMembers(String orgId, int page, int size) {
+    try {
+      OrganizationsEntity organizationsEntity = this.auth0Client.getMgmtClient().organizations();
+      Request<MembersPage> request = organizationsEntity.getMembers(orgId, null);
+      List<Member> items = request.execute().getBody().getItems();
+      return PagingHelper.toPage(items, page, size);
+    } catch (Auth0Exception e) {
+      throw VortexException.internalError("Failed to get members of organization: " + orgId);
+    }
+  }
+
+  public Invitation createInvitation(
+      String orgId, CreateInivitationDto request, String requestedBy) {
+
+    log.info("creating invitation:orgId:{}, {},requestedBy:{}", orgId, request, requestedBy);
+    try {
+      OrganizationsEntity organizationsEntity = this.auth0Client.getMgmtClient().organizations();
+      Organization organization = organizationsEntity.get(orgId).execute().getBody();
+
+      EnabledConnectionsPage enabledConnectionsPage =
+          organizationsEntity.getConnections(organization.getId(), null).execute().getBody();
+      if (enabledConnectionsPage.getItems().isEmpty()) {
+        throw VortexException.badRequest("No connection found for organization: " + orgId);
+      }
+
+      User currentUser =
+          this.auth0Client.getMgmtClient().users().get(requestedBy, null).execute().getBody();
+
+      Inviter inviter = new Inviter(currentUser.getName());
+      Invitee invitee = new Invitee(request.getEmail());
+
+      Invitation invitation =
+          new Invitation(inviter, invitee, auth0Client.getAuth0Property().getApp().getClientId());
+      invitation.setConnectionId(enabledConnectionsPage.getItems().get(0).getConnectionId());
+      invitation.setSendInvitationEmail(false);
+      invitation.setRoles(getRoles(orgId, request));
+
+      Request<Invitation> invitationRequest =
+          organizationsEntity.createInvitation(orgId, invitation);
+      return invitationRequest.execute().getBody();
+    } catch (Auth0Exception e) {
+      log.error("create invitations.error", e);
+      throw VortexException.internalError("Failed to create invitations of organization: " + orgId);
+    }
+  }
+
+  private Roles getRoles(String orgId, CreateInivitationDto request) {
+    List<String> roleIds = new ArrayList<>();
+
+    // check if the user is mgmt
+    boolean isMgmt = orgId.equalsIgnoreCase(auth0Client.getAuth0Property().getMgmtOrgId());
+
+    // assign mgmt role to the user
+    if (isMgmt) {
+      roleIds.add(auth0Client.getAuth0Property().getRoles().getMgmtRoleId());
+    }
+
+    // assign admin or user role to the user
+    if (request.getRole() == RoleEnum.ADMIN) {
+      roleIds.add(auth0Client.getAuth0Property().getRoles().getAdminRoleId());
+    } else {
+      roleIds.add(auth0Client.getAuth0Property().getRoles().getUserRoleId());
+    }
+    Roles roles = new Roles(roleIds);
+    return roles;
+  }
+
+  public Paging<Invitation> listInvitations(String orgId, int page, int size) {
+    try {
+      OrganizationsEntity organizationsEntity = this.auth0Client.getMgmtClient().organizations();
+      Request<InvitationsPage> request = organizationsEntity.getInvitations(orgId, null);
+      List<Invitation> items = request.execute().getBody().getItems();
+      return PagingHelper.toPage(items, page, size);
+    } catch (Auth0Exception e) {
+      throw VortexException.internalError("Failed to get invitations of organization: " + orgId);
+    }
+  }
+
+  public Invitation getInvitationById(String orgId, String invitationId) {
+    try {
+      OrganizationsEntity organizationsEntity = this.auth0Client.getMgmtClient().organizations();
+      Request<Invitation> request = organizationsEntity.getInvitation(orgId, invitationId, null);
+      return request.execute().getBody();
+    } catch (Auth0Exception e) {
+      throw VortexException.internalError("Failed to get invitation: " + invitationId);
+    }
+  }
+
+  public void deleteInvitation(String orgId, String invitationId, String requestedBy) {
+    log.info(
+        "deleting invitation:orgId:{}, invitationId:{},requestedBy:{}",
+        orgId,
+        invitationId,
+        requestedBy);
+    try {
+      OrganizationsEntity organizationsEntity = this.auth0Client.getMgmtClient().organizations();
+      Request<Void> request = organizationsEntity.deleteInvitation(orgId, invitationId);
+      request.execute().getBody();
+    } catch (Auth0Exception e) {
+      throw VortexException.internalError("Failed to delete invitation: " + invitationId);
+    }
+  }
+
+  public Paging<Role> listRoles(String orgId, int page, int size) {
+    List<String> roleIds =
+        List.of(
+            auth0Client.getAuth0Property().getRoles().getAdminRoleId(),
+            auth0Client.getAuth0Property().getRoles().getUserRoleId());
+    try {
+      RolesEntity rolesEntity = this.auth0Client.getMgmtClient().roles();
+      List<Role> items =
+          rolesEntity.list(null).execute().getBody().getItems().stream()
+              .filter(role -> roleIds.contains(role.getId()))
+              .toList();
+
+      return PagingHelper.toPage(items, page, size);
+    } catch (Auth0Exception e) {
+      throw VortexException.internalError("Failed to get roles of organization: " + orgId);
     }
   }
 }

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/OrganizationService.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/OrganizationService.java
@@ -132,8 +132,7 @@ public class OrganizationService {
     } else {
       roleIds.add(auth0Client.getAuth0Property().getRoles().getUserRoleId());
     }
-    Roles roles = new Roles(roleIds);
-    return roles;
+    return new Roles(roleIds);
   }
 
   public Paging<Invitation> listInvitations(String orgId, int page, int size) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Add the following endpoints:

1. List a organization's members
```
GET /organizations/{orgId}/members
```
2. List all pending inviations

```
GET /organizations/{orgId}/invitations
```
3. Create a inviation

```
POST /organizations/{orgId}/invitations
```

4. Retrieve a invitation details by id

```
GET /organizations/{orgId}/invitations/{inviationId}
```

5. Delete a invitatioin
```
DELETE /organizations/{orgId}/invitations/{inviationId}
```

6. List avaiables roles

```
/GET /organizations/{orgId}/roles
```

And following env variables are required:
```
AUTH0_MGMT_API_CLIENT_ID
AUTH0_MGMT_API_CLIENT_SECRET
AUTH0_MGMT_API_DOMAIN
AUTH0_MGMT_API_AUDIENCE
AUTH0_APP_CLIENT_ID
AUTH0_MGMT_ORG_ID
AUTH0_MGMT_ROLE_ID
AUTH0_ADMIN_ROLE_ID
AUTH0_USER_ROLE_ID
```

