### PR TITLE
feat(sdk): ingest UserContext after auth done

### DIFF
--- a/vortex-app/vortex-app-api/src/main/resources/application.yaml
+++ b/vortex-app/vortex-app-api/src/main/resources/application.yaml
@@ -118,6 +118,7 @@ app:
         audience: ${IAM_AUTH0_MGMT_API_AUDIENCE:https://partner.consoleconnect.com/api}
       app:
         client-id: ${IAM_AUTH0_APP_CLIENT_ID:app-client-id}
+      mgmt-org-id: ${IAM_AUTH0_MGMT_ORG_ID:}
       roles:
         - role-id: ${IAM_AUTH0_ROLES_MGMT_ADMIN_ROLE_ID:}
           org-ids:

--- a/vortex-java-sdk/vortex-java-sdk-gateway/pom.xml
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/pom.xml
@@ -17,7 +17,7 @@
         
         <dependency>
             <groupId>com.consoleconnect.vortex</groupId>
-            <artifactId>vortex-java-sdk-core</artifactId>
+            <artifactId>vortex-java-sdk-iam</artifactId>
             <version>0.1.0-preview</version>
         </dependency>
 

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/filter/SetAPIKeyGatewayFilterFactory.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/filter/SetAPIKeyGatewayFilterFactory.java
@@ -1,12 +1,16 @@
 package com.consoleconnect.vortex.gateway.filter;
 
+import com.consoleconnect.vortex.iam.model.IamConstants;
+import com.consoleconnect.vortex.iam.model.UserContext;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 
 @Component
+@Slf4j
 public class SetAPIKeyGatewayFilterFactory
     extends AbstractGatewayFilterFactory<SetAPIKeyGatewayFilterFactory.Config> {
 
@@ -18,21 +22,23 @@ public class SetAPIKeyGatewayFilterFactory
   public GatewayFilter apply(Config config) {
     // ...
     return ((exchange, chain) -> {
-      String role = exchange.getAttribute("x-vortex-user-role");
+      UserContext userContext = exchange.getAttribute(IamConstants.X_VORTEX_USER_CONTEXT);
+      if (userContext == null) {
+        log.warn("User context is null,SetAPIKeyGatewayFilterFactory will not be applied");
+        return chain.filter(exchange);
+      } else {
+        String apiKeyValue = userContext.isMgmt() ? config.getAdminKey() : config.getUserKey();
+        ServerWebExchange updatedExchange =
+            exchange
+                .mutate()
+                .request(
+                    request ->
+                        request.headers(
+                            httpHeaders -> httpHeaders.add(config.getKeyName(), apiKeyValue)))
+                .build();
 
-      String apiKeyValue =
-          "admin".equalsIgnoreCase(role) ? config.getAdminKey() : config.getUserKey();
-
-      ServerWebExchange updatedExchange =
-          exchange
-              .mutate()
-              .request(
-                  request ->
-                      request.headers(
-                          httpHeaders -> httpHeaders.add(config.getKeyName(), apiKeyValue)))
-              .build();
-
-      return chain.filter(updatedExchange);
+        return chain.filter(updatedExchange);
+      }
     });
   }
 

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/IamConstants.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/IamConstants.java
@@ -1,0 +1,8 @@
+package com.consoleconnect.vortex.iam.model;
+
+public final class IamConstants {
+  private IamConstants() {}
+
+  public static final String X_VORTEX_CUSTOMER_ORG_ID = "x-vortex-customer-org-id";
+  public static final String X_VORTEX_USER_CONTEXT = "x-user-context";
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/UserContext.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/UserContext.java
@@ -1,0 +1,15 @@
+package com.consoleconnect.vortex.iam.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserContext {
+  private String userId;
+  private String orgId;
+  private boolean mgmt;
+  private String customerId;
+}

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/PermissionService.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/PermissionService.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 public class PermissionService {
   private final Auth0Client auth0Client;
 
-  // TODO: implemeting caching for permissions
+  // TODO: implementing caching for permissions
   public List<Permission> listPermissions(String roleId) {
     try {
       return auth0Client


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

based on the bearer token in the http request, after security check passed,  the following user context will be added into the ServerWebExchange.attributes

```
x-vortex-user-context: {
     userId:  string
     orgId: string
     isMgmt: boolean
     customerOrgId: string  // nullable
}
```

Pls take note
customerOrgId is parsed from the current http request headers
```
x-customer-org-id
```
