### PR TITLE
feat(sdk): enable role-based access control

### DIFF
--- a/vortex-app/vortex-app-api/src/main/resources/application.yaml
+++ b/vortex-app/vortex-app-api/src/main/resources/application.yaml
@@ -119,16 +119,6 @@ app:
       app:
         client-id: ${IAM_AUTH0_APP_CLIENT_ID:app-client-id}
       mgmt-org-id: ${IAM_AUTH0_MGMT_ORG_ID:}
-      roles:
-        - role-id: ${IAM_AUTH0_ROLES_MGMT_ADMIN_ROLE_ID:}
-          org-ids:
-            - ${IAM_AUTH0_MGMT_ORG_ID:}
-        - role-id: ${IAM_AUTH0_ROLES_MGMT_USER_ROLE_ID:}
-          org-ids:
-            - ${IAM_AUTH0_ORG_MGMT_ID:}
-        - role-id: ${IAM_AUTH0_ROLES_ORG_ADMIN_ROLE_ID:}
-        - role-id: ${IAM_AUTH0_ROLES_ORG_USER_ROLE_ID:}
-
     email:
       enabled: ${IAM_EMAIL_ENABLED:false}
       provider: ${IAM_EMAIL_PROVIDER:sendgrid}
@@ -139,6 +129,34 @@ app:
           email: ${SENDGRID_FROM_EMAIL:}
         templates:
           invite-org-member: ${SENDGRID_TEMPLATE_ID_ORG_INVITE:}
+    resource-server:
+      path-permissions:
+        - path: /mgmt/**
+          http-methods:
+            - POST
+            - DELETE
+            - PATCH
+          roles:
+            - PLATFORM_ADMIN
+        - path: /mgmt/**
+          http-methods:
+            - GET
+          roles:
+            - PLATFORM_ADMIN
+            - PLATFORM_USER
+        - path: /organization/**
+          http-methods:
+            - POST
+            - PATCH
+            - DELETE
+          roles:
+            - ORG_ADMIN
+        - path: /organization/**
+          http-methods:
+            - GET
+          roles:
+            - ORG_ADMIN
+            - ORG_USER
   gateway:
     downstream:
       base-url: ${GATEWAY_DOWN_STREAM_BASE_URL:http://localhost:3000}

--- a/vortex-e2e/vortex-e2e-app-api/pom.xml
+++ b/vortex-e2e/vortex-e2e-app-api/pom.xml
@@ -2,14 +2,19 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.consoleconnect.vortex</groupId>
     <artifactId>vortext-e2e-app-api</artifactId>
     <version>0.1.0-preview</version>
     <packaging>jar</packaging>
 
+    <parent>
+        <groupId>com.consoleconnect.vortex</groupId>
+        <artifactId>vortex-e2e</artifactId>
+        <version>0.1.0-preview</version>
+    </parent>
+
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+<!--        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>-->
+<!--        <java.version>17</java.version>-->
         <maven.compiler.version>3.11.0</maven.compiler.version>
         <maven.surefire.version>3.0.0</maven.surefire.version>
         <karate.version>1.5.0</karate.version>

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/MgmtOrganizationController.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/MgmtOrganizationController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -28,7 +27,6 @@ public class MgmtOrganizationController {
 
   private final OrganizationService service;
 
-  @PreAuthorize("hasPermission('mgmt:org', 'list')")
   @Operation(summary = "List all existing organizations")
   @GetMapping("")
   public Mono<HttpResponse<Paging<Organization>>> search(
@@ -41,7 +39,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(service.search(q, page, size)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'create')")
   @Operation(summary = "Create a new organization")
   @PostMapping("")
   public Mono<HttpResponse<Organization>> create(
@@ -49,7 +46,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(service.create(request, authenticationToken.getName())));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'update')")
   @Operation(summary = "update a organization")
   @PatchMapping("/{orgId}")
   public Mono<HttpResponse<Organization>> update(
@@ -60,14 +56,12 @@ public class MgmtOrganizationController {
         HttpResponse.ok(service.update(orgId, request, authenticationToken.getName())));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'read') ")
   @Operation(summary = "Retrieve an organization by id")
   @GetMapping("/{orgId}")
   public Mono<HttpResponse<Organization>> findOne(@PathVariable String orgId) {
     return Mono.just(HttpResponse.ok(service.findOne(orgId)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'read')")
   @Operation(summary = "List all existing connections")
   @GetMapping("/{orgId}/connections")
   public Mono<HttpResponse<Paging<OrganizationConnection>>> listConnections(
@@ -79,7 +73,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(service.listConnections(orgId, page, size)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'update')")
   @Operation(summary = "Setup a connection")
   @PostMapping("/{orgId}/connections")
   public Mono<HttpResponse<OrganizationConnection>> createConnection(
@@ -90,7 +83,6 @@ public class MgmtOrganizationController {
         HttpResponse.ok(service.createConnection(orgId, request, authenticationToken.getName())));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'read')")
   @Operation(summary = "List all invitations")
   @GetMapping("/{orgId}/invitations")
   public Mono<HttpResponse<Paging<Invitation>>> listInivitations(
@@ -102,7 +94,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(service.listInvitations(orgId, page, size)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'update')")
   @Operation(summary = "Create a new invitation")
   @PostMapping("/{orgId}/invitations")
   public Mono<HttpResponse<Invitation>> create(
@@ -114,7 +105,6 @@ public class MgmtOrganizationController {
             service.createInvitation(orgId, request, jwtAuthenticationToken.getName())));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'read')")
   @Operation(summary = "Retrieve an invitation by id")
   @GetMapping("/{orgId}/invitations/{invitationId}")
   public Mono<HttpResponse<Invitation>> findOne(
@@ -122,7 +112,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(service.getInvitationById(orgId, invitationId)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'update')")
   @Operation(summary = "Delete an invitation by id")
   @DeleteMapping("/{orgId}/invitations/{invitationId}")
   public Mono<HttpResponse<Void>> delete(
@@ -133,7 +122,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(null));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'read')")
   @Operation(summary = "List all members")
   @GetMapping("/{orgId}/members")
   public Mono<HttpResponse<Paging<Member>>> listMembers(
@@ -145,7 +133,6 @@ public class MgmtOrganizationController {
     return Mono.just(HttpResponse.ok(service.listMembers(orgId, page, size)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:org', 'read')")
   @Operation(summary = "List all roles")
   @GetMapping("/{orgId}/roles")
   public Mono<HttpResponse<Paging<Role>>> listRoles(

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/MgmtRoleController.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/MgmtRoleController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -24,7 +23,6 @@ public class MgmtRoleController {
 
   private final UserService service;
 
-  @PreAuthorize("hasPermission('mgmt:role', 'list')")
   @Operation(summary = "List all existing roles")
   @GetMapping("")
   public Mono<HttpResponse<Paging<Role>>> search(
@@ -35,7 +33,6 @@ public class MgmtRoleController {
     return Mono.just(HttpResponse.ok(service.listRoles(page, size)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:role', 'read')")
   @Operation(summary = "Retrieve a role by id")
   @GetMapping("/{roleId}")
   public Mono<HttpResponse<RoleInfo>> findOne(@PathVariable String roleId) {

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/MgmtUserController.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/controller/MgmtUserController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
@@ -24,7 +23,6 @@ public class MgmtUserController {
 
   private final UserService service;
 
-  @PreAuthorize("hasPermission('mgmt:user', 'list')")
   @Operation(summary = "List all existing users")
   @GetMapping("")
   public Mono<HttpResponse<Paging<User>>> search(
@@ -37,7 +35,6 @@ public class MgmtUserController {
     return Mono.just(HttpResponse.ok(service.searchUsers(q, email, page, size)));
   }
 
-  @PreAuthorize("hasPermission('mgmt:user', 'read') ")
   @Operation(summary = "Retrieve an user by id")
   @GetMapping("/{userId}")
   public Mono<HttpResponse<UserInfo>> findOne(@PathVariable String userId) {

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/enums/RoleEnum.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/enums/RoleEnum.java
@@ -1,6 +1,8 @@
 package com.consoleconnect.vortex.iam.enums;
 
 public enum RoleEnum {
-  ADMIN,
-  USER
+  PLATFORM_ADMIN,
+  PLATFORM_MEMBER,
+  ORG_ADMIN,
+  ORG_MEMBER
 }

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/Auth0Property.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/model/Auth0Property.java
@@ -1,6 +1,5 @@
 package com.consoleconnect.vortex.iam.model;
 
-import java.util.List;
 import lombok.Data;
 
 @Data
@@ -9,7 +8,6 @@ public class Auth0Property {
   private Config mgmtApi;
   private Config app;
 
-  private List<Role> roles;
   private String mgmtOrgId;
 
   @Data
@@ -18,11 +16,5 @@ public class Auth0Property {
     private String clientId;
     private String clientSecret;
     private String audience;
-  }
-
-  @Data
-  public static class Role {
-    private String roleId;
-    private List<String> orgIds;
   }
 }

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/UserContextService.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/UserContextService.java
@@ -1,0 +1,46 @@
+package com.consoleconnect.vortex.iam.service;
+
+import com.consoleconnect.vortex.iam.model.IamProperty;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.jwt.JwtClaimAccessor;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@AllArgsConstructor
+@Service
+@Slf4j
+public class UserContextService {
+  private final IamProperty iamProperty;
+  public static final String ANONYMOUS = "anonymous";
+
+  public Mono<String> getOrgId() {
+    return getAuthentication()
+        .map(JwtAuthenticationToken::getToken)
+        .map(JwtClaimAccessor::getClaims)
+        .map(claim -> claim.get(iamProperty.getJwt().getCustomClaims().getOrgId()))
+        .map(Object::toString)
+        .switchIfEmpty(Mono.just(ANONYMOUS));
+  }
+
+  public static Mono<String> getUserId() {
+    return getAuthentication()
+        .map(JwtAuthenticationToken::getToken)
+        .map(JwtClaimAccessor::getSubject)
+        .switchIfEmpty(Mono.just(ANONYMOUS));
+  }
+
+  public static Mono<JwtAuthenticationToken> getAuthentication() {
+    try {
+      return ReactiveSecurityContextHolder.getContext()
+          .map(SecurityContext::getAuthentication)
+          .cast(JwtAuthenticationToken.class);
+    } catch (Exception ex) {
+      log.warn("Failed to get authentication", ex);
+      return Mono.empty();
+    }
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

1. rename /organizations/{orgId}/** to /organization, the orgId will be parsed automatically based on the accessToken
2. remove the permission control configuration ( preAhtorize("hasPermission(...))
3. access control via roles
4. Pre-defined the following roles:
     PLATFORM_ADMIN: Access all /mgmt/*** endpoints
     PLATFORM_MEMBER: READONLY endpoints /mgmt/***

    ORG_ADMIN: access all endpints /organization/***
    ORG_MEMBER: readonly access endpoints /organization/***