### PR TITLE
build(misc): add github action to create tag and release

### DIFF
--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -13,6 +13,8 @@ jobs:
   bump-version:
     name: Create release in ${{ inputs.branch }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - name: Check out the repo

--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -17,6 +17,13 @@ jobs:
       contents: write
     steps:
 
+      - name: Get Github App token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69  # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
@@ -42,6 +49,6 @@ jobs:
 
       - name: Create a PR for the new version
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create v${{ steps.vars.outputs.current-version }} --generate-notes

--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -1,0 +1,45 @@
+---
+name: Create tag and release
+on:
+  workflow_dispatch:
+    inputs:
+      branch: 
+        description: 'The branch checkout'
+        required: false
+        type: string
+        default: 'main'
+
+jobs:
+  bump-version:
+    name: Create release in ${{ inputs.branch }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Get the current version
+        id: vars
+        run: |
+          git log -n 5
+          CURRENT_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo $CURRENT_VERSION
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+      - name: initialize git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Create git tag
+        run: |
+          git tag -a v${{ steps.vars.outputs.current-version }} -m v${{ steps.vars.outputs.current-version }}
+          git push --tags
+
+      - name: Create a PR for the new version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create v${{ steps.vars.outputs.current-version }} --generate-notes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/workflows @mycloudnexus/vortex-code-approver


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

1. add a new github action to create tag and release based on the input branch.
2. the github action will be triggered manually

the github action will run the following commands:

```
git checkout $branch
CURRENT_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
git tag -a v$CURRENT_VERSION -m v$CURRENT_VERSION
git push --tags

GH release create v$CURRENT_VERSION --generate-notes

```