### PR TITLE
build(misc): use github-app to create pr instead of default github-token

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -16,7 +16,15 @@ jobs:
   bump-version:
     name: Bump version to ${{ inputs.new-version }} in ${{ inputs.branch }} 
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
     steps:
+      - name: Get Github App token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69  # v1.11.0
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -47,7 +55,7 @@ jobs:
       - name: Create a PR for the new version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git push -u origin "bump-version/${{ inputs.new-version }}"
           gh pr create --title "build(misc): bump version to ${{ inputs.new-version }} in ${{ inputs.branch }}" --body "Bump version to ${{ inputs.new-version }} " --base ${{inputs.branch}}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

this existing bump-version.yaml will create a PR via the github-token, but the new created PR won't trigger the CI.
More details can be found:
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow


This patch will use the github-app token to create the PR to bump version.


Ref: https://github.com/mycloudnexus/vortex/pull/34
