### PR TITLE
fix(sdk): decode and encode response

### DIFF
--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/filter/ResponseAdapterGatewayFilterFactory.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/filter/ResponseAdapterGatewayFilterFactory.java
@@ -1,18 +1,27 @@
 package com.consoleconnect.vortex.gateway.filter;
 
+import static java.util.function.Function.identity;
+
 import com.consoleconnect.vortex.gateway.adapter.RouteAdapter;
 import com.consoleconnect.vortex.gateway.adapter.RouteAdapterFactory;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.NettyWriteResponseFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyDecoder;
+import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyEncoder;
 import org.springframework.core.Ordered;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.stereotype.Component;
@@ -26,10 +35,21 @@ public class ResponseAdapterGatewayFilterFactory
     extends AbstractGatewayFilterFactory<AbstractGatewayFilterFactory.NameConfig> {
 
   private final RouteAdapterFactory adapterFactory;
+  private final Map<String, MessageBodyDecoder> messageBodyDecoders;
+  private final Map<String, MessageBodyEncoder> messageBodyEncoders;
 
-  public ResponseAdapterGatewayFilterFactory(RouteAdapterFactory adapterFactory) {
+  public ResponseAdapterGatewayFilterFactory(
+      RouteAdapterFactory adapterFactory,
+      Set<MessageBodyDecoder> messageBodyDecoders,
+      Set<MessageBodyEncoder> messageBodyEncoders) {
     super(NameConfig.class);
     this.adapterFactory = adapterFactory;
+    this.messageBodyDecoders =
+        messageBodyDecoders.stream()
+            .collect(Collectors.toMap(MessageBodyDecoder::encodingType, identity()));
+    this.messageBodyEncoders =
+        messageBodyEncoders.stream()
+            .collect(Collectors.toMap(MessageBodyEncoder::encodingType, identity()));
   }
 
   @Override
@@ -71,31 +91,56 @@ public class ResponseAdapterGatewayFilterFactory
                                 .map(
                                     // Step 2: read response body
                                     dataBuffers -> {
-                                      ByteArrayOutputStream outputStream =
-                                          new ByteArrayOutputStream();
-                                      dataBuffers.stream()
-                                          .forEach(
-                                              buffer -> {
-                                                byte[] bytes = new byte[buffer.readableByteCount()];
-                                                buffer.read(bytes);
-                                                DataBufferUtils.release(buffer);
-                                                try {
-                                                  outputStream.write(bytes);
-                                                } catch (IOException e) {
-                                                  log.info("response body read bytes failed", e);
-                                                }
-                                              });
+                                      DataBufferFactory bufFactory = new DefaultDataBufferFactory();
+                                      DataBuffer buffer = bufFactory.join(dataBuffers);
 
-                                      byte[] originalBody = outputStream.toByteArray();
-                                      // Step 3: process the response body with the adapter
-                                      byte[] resBody = adapter.process(exchange, originalBody);
-                                      return bufferFactory().wrap(resBody);
+                                      byte[] content = new byte[buffer.readableByteCount()];
+                                      buffer.read(content);
+                                      DataBufferUtils.release(buffer);
+
+                                      // Step 3: decode
+                                      content = extractBody(exchange, content);
+
+                                      // Step 4: process the response body with the adapter
+                                      byte[] resBody = adapter.process(exchange, content);
+
+                                      // Step 5: encode
+                                      return bufferFactory().wrap(writeBody(exchange, resBody));
                                     }));
                       }
                       return super.writeWith(body);
                     }
                   })
               .build());
+    }
+
+    private byte[] extractBody(ServerWebExchange exchange, byte[] resBytes) {
+
+      List<String> encodingHeaders =
+          exchange.getResponse().getHeaders().getOrEmpty(HttpHeaders.CONTENT_ENCODING);
+      for (String encoding : encodingHeaders) {
+        MessageBodyDecoder decoder = messageBodyDecoders.get(encoding);
+        log.info("extractBody encoding: {}, decoder{}", encoding, decoder.getClass());
+        if (decoder != null) {
+          return decoder.decode(resBytes);
+        }
+      }
+      return resBytes;
+    }
+
+    private byte[] writeBody(ServerWebExchange exchange, byte[] resBytes) {
+      List<String> encodingHeaders =
+          exchange.getResponse().getHeaders().getOrEmpty(HttpHeaders.CONTENT_ENCODING);
+      for (String encoding : encodingHeaders) {
+        MessageBodyEncoder encoder = messageBodyEncoders.get(encoding);
+        if (encoder != null) {
+          log.info("extractBody encoding: {}, encoder{}", encoding, encoder.getClass());
+          DataBufferFactory bufferFactory = exchange.getResponse().bufferFactory();
+          return encoder.encode(bufferFactory.wrap(resBytes));
+        }
+      }
+
+      return resBytes;
     }
 
     @Override

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/test/java/com/consoleconnect/vortex/gateway/GatewayFilterFactoryTest.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/test/java/com/consoleconnect/vortex/gateway/GatewayFilterFactoryTest.java
@@ -14,6 +14,7 @@ import com.consoleconnect.vortex.iam.model.UserContext;
 import com.consoleconnect.vortex.test.AbstractIntegrationTest;
 import com.consoleconnect.vortex.test.MockIntegrationTest;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +24,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyDecoder;
+import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyEncoder;
 import org.springframework.core.io.buffer.DefaultDataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.HttpStatus;
@@ -43,6 +46,9 @@ class GatewayFilterFactoryTest extends AbstractIntegrationTest {
 
   @Autowired private RouteAdapterFactory adapterFactory;
 
+  @Autowired private Set<MessageBodyDecoder> messageBodyDecoders;
+  @Autowired private Set<MessageBodyEncoder> messageBodyEncoders;
+
   private ServerWebExchange exchange;
   private AbstractGatewayFilterFactory.NameConfig config =
       new AbstractGatewayFilterFactory.NameConfig();
@@ -52,7 +58,9 @@ class GatewayFilterFactoryTest extends AbstractIntegrationTest {
   @BeforeEach
   void setUp() {
     config.setName("name");
-    filterFactory = new ResponseAdapterGatewayFilterFactory(adapterFactory);
+    filterFactory =
+        new ResponseAdapterGatewayFilterFactory(
+            adapterFactory, messageBodyDecoders, messageBodyEncoders);
 
     MockServerHttpRequest request =
         MockServerHttpRequest.put(

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/test/java/com/consoleconnect/vortex/gateway/GatewayFilterFactoryTest.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/test/java/com/consoleconnect/vortex/gateway/GatewayFilterFactoryTest.java
@@ -13,7 +13,6 @@ import com.consoleconnect.vortex.iam.model.IamConstants;
 import com.consoleconnect.vortex.iam.model.UserContext;
 import com.consoleconnect.vortex.test.AbstractIntegrationTest;
 import com.consoleconnect.vortex.test.MockIntegrationTest;
-import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
@@ -28,6 +27,7 @@ import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyDecod
 import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyEncoder;
 import org.springframework.core.io.buffer.DefaultDataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.support.DefaultServerCodecConfigurer;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
@@ -44,8 +44,13 @@ import reactor.test.StepVerifier;
 @MockIntegrationTest
 class GatewayFilterFactoryTest extends AbstractIntegrationTest {
 
-  @Autowired private RouteAdapterFactory adapterFactory;
+  byte[] resBytes =
+      new byte[] {
+        31, -117, 8, 0, 0, 0, 0, 0, 0, -1, -85, 86, -54, 76, 81, -78, 82, -54, 76, 49, 48, 48, 4,
+        35, -91, 90, 0, -8, 26, 77, 18, 19, 0, 0, 0
+      };
 
+  @Autowired private RouteAdapterFactory adapterFactory;
   @Autowired private Set<MessageBodyDecoder> messageBodyDecoders;
   @Autowired private Set<MessageBodyEncoder> messageBodyEncoders;
 
@@ -70,6 +75,7 @@ class GatewayFilterFactoryTest extends AbstractIntegrationTest {
 
     MockServerHttpResponse response = new MockServerHttpResponse();
     response.setStatusCode(HttpStatus.OK);
+    response.getHeaders().add(HttpHeaders.CONTENT_ENCODING, "gzip");
 
     exchange =
         new DefaultServerWebExchange(
@@ -89,8 +95,8 @@ class GatewayFilterFactoryTest extends AbstractIntegrationTest {
         .thenAnswer(
             invocation -> {
               ServerWebExchange ex = invocation.getArgument(0);
-              byte[] bytes = "{\"id\":\"id00100100\"}".getBytes(StandardCharsets.UTF_8);
-              DefaultDataBuffer buffer = new DefaultDataBufferFactory().wrap(bytes);
+
+              DefaultDataBuffer buffer = new DefaultDataBufferFactory().wrap(resBytes);
               return ex.getResponse().writeWith(Flux.just(buffer));
             });
   }


### PR DESCRIPTION
1. Easier code to read response body bytes with DataBufferFactory
3. decode and encode the response body when the response header includes compress type (gzip)