### PR TITLE
feat(sdk): add ResourceBodyTransformer filter

### DIFF
--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/filter/ResponseBodyTransformerGatewayFilterFactory.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/filter/ResponseBodyTransformerGatewayFilterFactory.java
@@ -1,0 +1,174 @@
+package com.consoleconnect.vortex.gateway.filter;
+
+import static java.util.function.Function.identity;
+
+import com.consoleconnect.vortex.gateway.enums.ResourceTypeEnum;
+import com.consoleconnect.vortex.gateway.transformer.AbstractResourceTransformer;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyDecoder;
+import org.springframework.cloud.gateway.filter.factory.rewrite.MessageBodyEncoder;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class ResponseBodyTransformerGatewayFilterFactory
+    extends AbstractGatewayFilterFactory<ResponseBodyTransformerGatewayFilterFactory.Config> {
+
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+  private final Map<String, MessageBodyDecoder> messageBodyDecoders;
+  private final Map<String, MessageBodyEncoder> messageBodyEncoders;
+
+  private final List<AbstractResourceTransformer> transformers;
+
+  public ResponseBodyTransformerGatewayFilterFactory(
+      Set<MessageBodyDecoder> messageBodyDecoders,
+      Set<MessageBodyEncoder> messageBodyEncoders,
+      List<AbstractResourceTransformer> transformers) {
+    super(Config.class);
+    this.messageBodyDecoders =
+        messageBodyDecoders.stream()
+            .collect(Collectors.toMap(MessageBodyDecoder::encodingType, identity()));
+    this.messageBodyEncoders =
+        messageBodyEncoders.stream()
+            .collect(Collectors.toMap(MessageBodyEncoder::encodingType, identity()));
+    this.transformers = transformers;
+  }
+
+  private String buildFullPath(HttpMethod method, String routePath) {
+    return method.name() + " " + routePath;
+  }
+
+  private boolean match(Config config, ServerWebExchange exchange) {
+    String pattern = buildFullPath(config.getHttpMethod(), config.getHttpPath());
+    String path =
+        buildFullPath(exchange.getRequest().getMethod(), exchange.getRequest().getPath().value());
+    return pathMatcher.match(pattern, path);
+  }
+
+  private Optional<AbstractResourceTransformer> getTransformer(String transformer) {
+    return transformers.stream().filter(t -> t.getTransformerId().equals(transformer)).findFirst();
+  }
+
+  @Override
+  public GatewayFilter apply(Config config) {
+    return ((exchange, chain) -> {
+      if (!match(config, exchange)) {
+        return chain.filter(exchange);
+      }
+
+      final Optional<AbstractResourceTransformer> transformer =
+          getTransformer(config.getTransformer());
+      if (transformer.isEmpty()) {
+        log.warn(
+            "No transformer found,ResponseTransformerGatewayFilterFactory will not be applied");
+        return chain.filter(exchange);
+      } else {
+
+        ServerWebExchange updatedExchange =
+            exchange
+                .mutate()
+                .response(
+                    new ServerHttpResponseDecorator(exchange.getResponse()) {
+                      @Override
+                      public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
+                        HttpStatusCode statusCode = exchange.getResponse().getStatusCode();
+                        if (statusCode != null && statusCode.is2xxSuccessful()) {
+                          Flux<? extends DataBuffer> fluxBody = Flux.from(body);
+                          return super.writeWith(
+                              fluxBody
+                                  .buffer()
+                                  .map(
+                                      // Step 2: read response body
+                                      dataBuffers -> {
+                                        DataBufferFactory bufFactory =
+                                            new DefaultDataBufferFactory();
+                                        DataBuffer buffer = bufFactory.join(dataBuffers);
+
+                                        byte[] content = new byte[buffer.readableByteCount()];
+                                        buffer.read(content);
+                                        DataBufferUtils.release(buffer);
+
+                                        // Step 3: decode
+                                        content = extractBody(exchange, content);
+
+                                        // Step 4: process the response body with the adapter
+                                        byte[] resBody =
+                                            transformer.get().transform(exchange, content, config);
+
+                                        // Step 5: encode
+                                        return bufferFactory().wrap(writeBody(exchange, resBody));
+                                      }));
+                        }
+                        return super.writeWith(body);
+                      }
+                    })
+                .build();
+        return chain.filter(updatedExchange);
+      }
+    });
+  }
+
+  private byte[] extractBody(ServerWebExchange exchange, byte[] resBytes) {
+
+    List<String> encodingHeaders =
+        exchange.getResponse().getHeaders().getOrEmpty(HttpHeaders.CONTENT_ENCODING);
+    for (String encoding : encodingHeaders) {
+      MessageBodyDecoder decoder = messageBodyDecoders.get(encoding);
+      log.info("extractBody encoding: {}, decoder{}", encoding, decoder.getClass());
+      if (decoder != null) {
+        return decoder.decode(resBytes);
+      }
+    }
+    return resBytes;
+  }
+
+  private byte[] writeBody(ServerWebExchange exchange, byte[] resBytes) {
+    List<String> encodingHeaders =
+        exchange.getResponse().getHeaders().getOrEmpty(HttpHeaders.CONTENT_ENCODING);
+    for (String encoding : encodingHeaders) {
+      MessageBodyEncoder encoder = messageBodyEncoders.get(encoding);
+      if (encoder != null) {
+        log.info("extractBody encoding: {}, encoder{}", encoding, encoder.getClass());
+        DataBufferFactory bufferFactory = exchange.getResponse().bufferFactory();
+        return encoder.encode(bufferFactory.wrap(resBytes));
+      }
+    }
+
+    return resBytes;
+  }
+
+  @Data
+  public static class Config {
+    private HttpMethod httpMethod;
+    private String httpPath;
+    private String transformer;
+    private ResourceTypeEnum resourceType;
+    private String responseBodyPath = "$";
+    private String resourceOrderIdPath;
+    private String resourceInstanceIdPath;
+
+    private Map<String, Object> metadata;
+  }
+}

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/toolkit/JsonPathToolkit.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/toolkit/JsonPathToolkit.java
@@ -29,4 +29,8 @@ public class JsonPathToolkit {
   public static DocumentContext createDocCtx(String json) {
     return JsonPath.using(DEFAULT_CONFIGURATION).parse(json);
   }
+
+  public static DocumentContext createDocCtx(Object json) {
+    return JsonPath.using(DEFAULT_CONFIGURATION).parse(json);
+  }
 }

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/transformer/AbstractResourceTransformer.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/transformer/AbstractResourceTransformer.java
@@ -1,0 +1,39 @@
+package com.consoleconnect.vortex.gateway.transformer;
+
+import com.consoleconnect.vortex.core.exception.VortexException;
+import com.consoleconnect.vortex.gateway.filter.ResponseBodyTransformerGatewayFilterFactory;
+import com.consoleconnect.vortex.iam.model.IamConstants;
+import com.consoleconnect.vortex.iam.model.UserContext;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.server.ServerWebExchange;
+
+@Slf4j
+public abstract class AbstractResourceTransformer {
+
+  public final byte[] transform(
+      ServerWebExchange exchange,
+      byte[] responseBody,
+      ResponseBodyTransformerGatewayFilterFactory.Config config) {
+    long start = System.currentTimeMillis();
+    try {
+      UserContext userContext = exchange.getAttribute(IamConstants.X_VORTEX_USER_CONTEXT);
+      return doTransform(exchange, responseBody, userContext, config);
+    } catch (Exception e) {
+      log.error("{} process error.", getClass().getSimpleName(), e);
+      throw VortexException.badRequest("Failed to process", e);
+    } finally {
+      log.info(
+          "{} process cost: {} ms.",
+          getClass().getSimpleName(),
+          System.currentTimeMillis() - start);
+    }
+  }
+
+  protected abstract byte[] doTransform(
+      ServerWebExchange exchange,
+      byte[] responseBody,
+      UserContext userContext,
+      ResponseBodyTransformerGatewayFilterFactory.Config config);
+
+  public abstract String getTransformerId();
+}

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/transformer/CreateResourceResourceTransformer.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/transformer/CreateResourceResourceTransformer.java
@@ -1,0 +1,48 @@
+package com.consoleconnect.vortex.gateway.transformer;
+
+import com.consoleconnect.vortex.gateway.filter.ResponseBodyTransformerGatewayFilterFactory;
+import com.consoleconnect.vortex.gateway.service.OrderService;
+import com.consoleconnect.vortex.gateway.toolkit.JsonPathToolkit;
+import com.consoleconnect.vortex.iam.model.UserContext;
+import java.nio.charset.StandardCharsets;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ServerWebExchange;
+
+@AllArgsConstructor
+@Service
+@Slf4j
+public class CreateResourceResourceTransformer extends AbstractResourceTransformer {
+
+  protected final OrderService orderService;
+
+  public byte[] doTransform(
+      ServerWebExchange exchange,
+      byte[] responseBody,
+      UserContext userContext,
+      ResponseBodyTransformerGatewayFilterFactory.Config config) {
+    String orgId = userContext.getOrgId();
+    String response = new String(responseBody, StandardCharsets.UTF_8);
+    String orderId = null;
+    String resourceInstanceId = null;
+    if (!StringUtils.isBlank(config.getResourceOrderIdPath())) {
+      String orderIdPath =
+          String.format("%s.%s", config.getResponseBodyPath(), config.getResourceOrderIdPath());
+      orderId = JsonPathToolkit.read(response, orderIdPath);
+    }
+    if (!StringUtils.isBlank(config.getResourceInstanceIdPath())) {
+      String resourceInstanceIdPath =
+          String.format("%s.%s", config.getResponseBodyPath(), config.getResourceInstanceIdPath());
+      resourceInstanceId = JsonPathToolkit.read(response, resourceInstanceIdPath);
+    }
+    orderService.createOrder(orgId, orderId, config.getResourceType(), resourceInstanceId);
+    return responseBody;
+  }
+
+  @Override
+  public String getTransformerId() {
+    return "resource.create";
+  }
+}

--- a/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/transformer/ListResourcesResourceTransformer.java
+++ b/vortex-java-sdk/vortex-java-sdk-gateway/src/main/java/com/consoleconnect/vortex/gateway/transformer/ListResourcesResourceTransformer.java
@@ -1,0 +1,71 @@
+package com.consoleconnect.vortex.gateway.transformer;
+
+import com.consoleconnect.vortex.gateway.filter.ResponseBodyTransformerGatewayFilterFactory;
+import com.consoleconnect.vortex.gateway.service.OrderService;
+import com.consoleconnect.vortex.gateway.toolkit.JsonPathToolkit;
+import com.consoleconnect.vortex.iam.model.UserContext;
+import com.jayway.jsonpath.DocumentContext;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ServerWebExchange;
+
+@AllArgsConstructor
+@Service
+@Slf4j
+public class ListResourcesResourceTransformer extends AbstractResourceTransformer {
+
+  private final OrderService orderService;
+
+  public byte[] doTransform(
+      ServerWebExchange exchange,
+      byte[] responseBody,
+      UserContext userContext,
+      ResponseBodyTransformerGatewayFilterFactory.Config config) {
+
+    String orgId = userContext.getOrgId();
+
+    // filter resource by organization
+    //    Map<String, OrderEntity> resources =
+    //        orderService.listResourceByType(orgId, config.getResourceType()).stream()
+    //            .collect(Collectors.toMap(OrderEntity::getResourceId, x -> x));
+
+    //    Set<String> resourceIds = resources.keySet();
+
+    Set<String> resourceIds = new HashSet<>();
+
+    String responseJson = new String(responseBody, StandardCharsets.UTF_8);
+
+    DocumentContext dc = JsonPathToolkit.createDocCtx(responseJson);
+    List<Map<String, Object>> resOrders = dc.read(config.getResponseBodyPath());
+
+    // filter resources
+    resOrders.removeIf(o -> filterResource(resourceIds, o));
+
+    // override
+    DocumentContext ctx = JsonPathToolkit.createDocCtx(resOrders);
+
+    byte[] resBytes = ctx.jsonString().getBytes(StandardCharsets.UTF_8);
+    log.info("process completed, resourceType:{}", config.getResourceType());
+    return resBytes;
+  }
+
+  @Override
+  public String getTransformerId() {
+    return "resource.list";
+  }
+
+  // default filter
+  protected boolean filterResource(Set<String> resourceIds, Map<String, Object> dto) {
+    String oId = (String) dto.get("id");
+    if (resourceIds.contains(oId)) {
+      return Boolean.FALSE;
+    }
+    return Boolean.TRUE;
+  }
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

Plan to add a new filter to support response body transfomer:

For example, would like to extract the order.id  from the endpoint's response
https://api.consoleconnect.com/docs/tag/Port-Orders#operation/CreatePortOrder

the configuration can be:
```
  cloud:
    gateway:
      routes:
        - ...
          filters:
            - name: ResponseBodyTransformer
              args:
                  httpMethod: PUT
                  httpPath: /api/company/${companyName}/ports/orders
                  transformer: resource.create
                  resourceType: PORT
                  resourceBodyPath: $
                  resourceOrderIdPath: id
```

And if we would like to filter the data for 
https://api.consoleconnect.com/docs/tag/Ports#operation/GetPortList

the configuration can be:
```
  cloud:
    gateway:
      routes:
        - ...
          filters:
            - name: ResponseBodyTransformer
              args:
                  httpMethod: GET
                  httpPath: /api/company/${companyName}/ports
                  transformer: resource.list
                  resourceType: PORT
                  resourceBodyPath: $.results
                  resourceInstanceIdPath: id
```
