### PR TITLE
build(misc): add worfkow to build java sdk

### DIFF
--- a/.github/workflows/build-java-sdk.yml
+++ b/.github/workflows/build-java-sdk.yml
@@ -1,0 +1,61 @@
+---
+name: Build java sdk
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch checkout'
+        required: false
+        type: string
+        default: 'main'
+jobs:
+  java-sdk-release:
+    name: Build java sdk and publish to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Get the current version
+        id: vars
+        run: |
+          git log -n 5
+
+          COMMIT_HASH_SHORT=$(git rev-parse --short HEAD)
+          echo $COMMIT_HASH_SHORT
+
+          CURRENT_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo $CURRENT_VERSION
+          
+          DOCKER_IMAGE_TAG=$CURRENT_VERSION-$COMMIT_HASH_SHORT
+          echo "docker-image-tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available.
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Bump version in pom.xml files
+        run: |
+          echo "NEW_VERSION: ${{ steps.vars.outputs.docker-image-tag }}"
+          ./mvnw -q versions:set -DnewVersion=${{ steps.vars.outputs.docker-image-tag }} -DprocessAllModules
+
+      - name: Build and publish SDK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        run: ./mvnw -B deploy -DskipTests

--- a/.github/workflows/build-java-sdk.yml
+++ b/.github/workflows/build-java-sdk.yml
@@ -23,20 +23,6 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
 
-      - name: Get the current version
-        id: vars
-        run: |
-          git log -n 5
-
-          COMMIT_HASH_SHORT=$(git rev-parse --short HEAD)
-          echo $COMMIT_HASH_SHORT
-
-          CURRENT_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo $CURRENT_VERSION
-          
-          DOCKER_IMAGE_TAG=$CURRENT_VERSION-$COMMIT_HASH_SHORT
-          echo "docker-image-tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -50,12 +36,28 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Get the current version
+        id: vars
+        run: |
+          git log -n 5
+
+          COMMIT_HASH_SHORT=$(git rev-parse --short HEAD)
+          echo $COMMIT_HASH_SHORT
+
+          CURRENT_VERSION=$(./mvnw org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo $CURRENT_VERSION
+          
+          JAVA_SDK_VERSION=$CURRENT_VERSION-$COMMIT_HASH_SHORT
+          echo "java-sdk-version=JAVA_SDK_VERSION" >> $GITHUB_OUTPUT
+
+
       - name: Bump version in pom.xml files
         run: |
-          echo "NEW_VERSION: ${{ steps.vars.outputs.docker-image-tag }}"
-          ./mvnw -q versions:set -DnewVersion=${{ steps.vars.outputs.docker-image-tag }} -DprocessAllModules
+          echo "java-sdk-version: ${{ steps.vars.outputs.java-sdk-version }}"
+          ./mvnw -q versions:set -DnewVersion=${{ steps.vars.outputs.java-sdk-version }} -DprocessAllModules
 
       - name: Build and publish SDK
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        run: ./mvnw -B deploy -DskipTests
+        run: |
+          ./mvnw -B deploy -DskipTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,40 @@
 ---
-name: Container Release
+name: Container and Java Sdk release
 on:
   release:
     types: [published]
 jobs:
+  java-sdk-release:
+    name: Build java sdk and publish to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu' # Alternative distribution options are available.
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build and publish SDK
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        run: ./mvnw -B deploy -DskipTests
+
   container_release:
     name: Build docker images and publish to Docker Hub
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

1. Add a workflow to build java sdk on demand,  it will change the sdk to versioin {{current_version}+{{short-commit}} and publish to github packages
2. when a github release created, java sdk will be built and published to github packages