### PR TITLE
Add the `createdAt` filed when creating an organization.

### DIFF
--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/dto/OrganizationMetadata.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/dto/OrganizationMetadata.java
@@ -1,7 +1,9 @@
 package com.consoleconnect.vortex.iam.dto;
 
+import com.consoleconnect.vortex.core.toolkit.DateTime;
 import com.consoleconnect.vortex.iam.enums.ConnectionStrategyEnum;
 import com.consoleconnect.vortex.iam.enums.OrgStatusEnum;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
@@ -12,10 +14,12 @@ public class OrganizationMetadata {
   public static final String META_STATUS = "status";
   public static final String META_CONNECTION_ID = "connectionId";
   public static final String META_CONNECTION_STRATEGY = "strategy";
+  public static final String META_CREATED_AT = "createdAt";
 
   private OrgStatusEnum status = OrgStatusEnum.ACTIVE;
   private ConnectionStrategyEnum strategy = ConnectionStrategyEnum.UNDEFINED;
   private String connectionId;
+  private ZonedDateTime createdAt;
 
   public static OrganizationMetadata fromMap(Map<String, Object> map) {
     OrganizationMetadata metadata = new OrganizationMetadata();
@@ -30,7 +34,9 @@ public class OrganizationMetadata {
                 map.getOrDefault(
                     META_CONNECTION_STRATEGY, ConnectionStrategyEnum.UNDEFINED.name())));
     metadata.setConnectionId((String) map.get(META_CONNECTION_ID));
-
+    if (map.containsKey(META_CREATED_AT)) {
+      metadata.setCreatedAt(DateTime.of((String) map.get(META_CREATED_AT)));
+    }
     return metadata;
   }
 
@@ -50,6 +56,9 @@ public class OrganizationMetadata {
 
     if (metadata.getConnectionId() != null) {
       map.put(META_CONNECTION_ID, metadata.getConnectionId());
+    }
+    if (metadata.getCreatedAt() == null) {
+      map.put(META_CREATED_AT, DateTime.nowInUTCString());
     }
     return map;
   }

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/OrganizationService.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/service/OrganizationService.java
@@ -54,6 +54,8 @@ public class OrganizationService {
       OrganizationsEntity organizationsEntity = this.auth0Client.getMgmtClient().organizations();
       Organization organization = new Organization(request.getName());
       organization.setDisplayName(request.getDisplayName());
+      // remove createdAt
+      request.getMetadata().setCreatedAt(null);
       organization.setMetadata(OrganizationMetadata.toMap(request.getMetadata()));
       return OrganizationMapper.INSTANCE.toOrganizationInfo(
           organizationsEntity.create(organization).execute().getBody());


### PR DESCRIPTION
Add the `createdAt` field when creating an organization to support [https://jira.pccwglobal.com/browse/POPING-3398](url)

- Filter organization by created time.

![image](https://github.com/user-attachments/assets/740e1d1b-aad6-425f-80aa-e733809a656c)
