### PR TITLE
fix(sdk): fix library vulnerability severity

### DIFF
--- a/vortex-java-sdk/vortex-java-sdk-test/pom.xml
+++ b/vortex-java-sdk/vortex-java-sdk-test/pom.xml
@@ -103,12 +103,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>6.1.13</version>
+            <version>6.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>6.1.13</version>
+            <version>6.1.14</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
fix library vulnerability severity scan issue for the [pr-111](https://github.com/mycloudnexus/vortex/pull/111)
![image](https://github.com/user-attachments/assets/3cbb85a9-9747-4c81-a3db-ba9268147c27)
