### PR TITLE
fix(sdk): fix missing field when updating organization information.

### DIFF
--- a/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/dto/OrganizationMetadata.java
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/main/java/com/consoleconnect/vortex/iam/dto/OrganizationMetadata.java
@@ -3,6 +3,7 @@ package com.consoleconnect.vortex.iam.dto;
 import com.consoleconnect.vortex.core.toolkit.DateTime;
 import com.consoleconnect.vortex.iam.enums.ConnectionStrategyEnum;
 import com.consoleconnect.vortex.iam.enums.OrgStatusEnum;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -19,6 +20,8 @@ public class OrganizationMetadata {
   private OrgStatusEnum status = OrgStatusEnum.ACTIVE;
   private ConnectionStrategyEnum strategy = ConnectionStrategyEnum.UNDEFINED;
   private String connectionId;
+
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss", timezone = "UTC")
   private ZonedDateTime createdAt;
 
   public static OrganizationMetadata fromMap(Map<String, Object> map) {
@@ -59,6 +62,8 @@ public class OrganizationMetadata {
     }
     if (metadata.getCreatedAt() == null) {
       map.put(META_CREATED_AT, DateTime.nowInUTCString());
+    } else {
+      map.put(META_CREATED_AT, metadata.getCreatedAt().toInstant().toString());
     }
     return map;
   }

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/test/resources/auth0/get_api_v2_organizations.json
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/test/resources/auth0/get_api_v2_organizations.json
@@ -6,7 +6,8 @@
     "metadata": {
       "status": "ACTIVE",
       "strategy": "samlp",
-      "connectionId": "con_YNEZH8rgZ8sQz9Fq"
+      "connectionId": "con_YNEZH8rgZ8sQz9Fq",
+      "createdAt": "2024-12-19T07:48:54.749932691Z"
     }
   }
 ]

--- a/vortex-java-sdk/vortex-java-sdk-iam/src/test/resources/auth0/get_api_v2_organizations_{id}.json
+++ b/vortex-java-sdk/vortex-java-sdk-iam/src/test/resources/auth0/get_api_v2_organizations_{id}.json
@@ -5,6 +5,7 @@
   "metadata": {
     "status": "ACTIVE",
     "strategy": "samlp",
-    "connectionId": "con_YNEZH8rgZ8sQz9Fq"
+    "connectionId": "con_YNEZH8rgZ8sQz9Fq",
+    "createdAt": "2024-12-19T07:48:54.749932691Z"
   }
 }


### PR DESCRIPTION
## Description
1. Contain the `createdAt` field when updating an organization.
2. Add date format in response to the `/mgmt/organizations` endpoint.
Related ticket: [POPING-3398](https://jira.pccwglobal.com/browse/POPING-3398)
![image](https://github.com/user-attachments/assets/b7a7bc0f-b9b0-490b-8b93-7ae84831ed1e)

## Related Issue

> Fix missing field when updating organization information.

In Auth0, the field `createdAt` is in metadata with a type of HashMap. All metadata fields should be contained when updating an organization's information. Before this pr, the `createdAt` field is missed when updating.
![image](https://github.com/user-attachments/assets/646f22ff-802f-48be-bfee-fa3dc71efb07)

## Checklist
Click [here](https://docs.google.com/spreadsheets/d/1lFb7c9JRq5mHDEHqsXnON_dlsO7Wvb8A/edit?gid=849014340#gid=849014340).